### PR TITLE
rebase chart to ensure deploys with later versions of rp

### DIFF
--- a/kind/make.sh
+++ b/kind/make.sh
@@ -64,6 +64,6 @@ HOSTS=$(kubectl -n redpanda get svc -o json | jq -r '.items[] | select(.status.l
 echo "$HOSTS"
 BROKERS=$(echo "$HOSTS" | awk '{print $2":9092"}' | paste -s -d, -)
 echo "
-rpk api status --brokers $BROKERS
+rpk cluster metadata --brokers $BROKERS
 "
-rpk api status --brokers "$BROKERS" || true
+rpk cluster metadata --brokers "$BROKERS" || true

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -109,8 +109,8 @@ spec:
             {{- end }}
             "--advertise-rpc-addr={{ template "redpanda.rpc.advertise.address" . }}:{{ template "redpanda.rpc.advertise.port" . }}",
             "--rpc-addr={{ template "redpanda.rpc.listen.address" . }}:{{ template "redpanda.rpc.listen.port" . }}",
-            "--",
-            "--default-log-level={{ .Values.config.seastar.default_log_level }}"
+            "--default-log-level={{ .Values.config.seastar.default_log_level }}",
+            "--"
           ]
           ports:
             - containerPort: {{ .Values.config.redpanda.admin.port }}

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -48,6 +48,7 @@ config:
       # The port for the admin server.
       #
       # Metrics are served off of this port at /metrics.
+      address: 0.0.0.0
       port: 9644
     kafka_api:
       - name: internal
@@ -56,6 +57,7 @@ config:
         port: 9092
     rpc_server:
       # The port for the internal RPC server.
+      address: 0.0.0.0
       port: 33145
 
   rpk:


### PR DESCRIPTION
Updated the values.yaml:

Included address for admin server, else run fails.
Included address for rpc server, else initContainer fails.

Replaced deprecated rpk status with cluster metadata.